### PR TITLE
Update statisticalmodels-stopgap.jl

### DIFF
--- a/src/statisticalmodels-stopgap.jl
+++ b/src/statisticalmodels-stopgap.jl
@@ -34,7 +34,7 @@ function mle_nojac(model::StatisticalModel,data,thetai::Array{Float64,1}=rand(di
 		println(fcalls,": ",round(theta,3),", ",round(llk,3))
 		llk
 	end
-	df=Optim.DifferentiableFunction(ff)	
+	df=Optim.OnceDifferentiable(ff)	
 	ret = Optim.optimize(df, thetai,method=:cg,iterations=L)
 	println("  no jacobian, $(ret.iterations) iterations, $fcalls ff evaluations, final log-likelihood: $(round(-ret.f_minimum,4))")
 	ret.minimum
@@ -58,7 +58,7 @@ function mle_jac(model::StatisticalModel,data,thetai::Array{Float64,1}=rand(dim(
 		jac[:]=-res[2]
 		-res[1]
 	end
-	df=Optim.DifferentiableFunction(ff,fj!,ffj!)
+	df=Optim.OnceDifferentiable(ff,fj!,ffj!)
 	ret = Optim.optimize(df, thetai,method=:cg,iterations=L)
 	println("  with jacobian, $(ret.iterations) iterations, ($fcalls,$fjcalls,$ffjcalls) (ff,fj,ffj) evaluations, final log-likelihood: $(round(-ret.f_minimum,4))")
 	ret.minimum


### PR DESCRIPTION
# Replace the deprecated Optim.DifferentiableFunction by Optim.OnceDifferentiable

I am unable to Pkg.add("DynamicDiscreteModels") or Pkg.clone("git://github.com/BenConnault/RustModels.jl.git"). The error messages are copied at the bottom. I wonder whether this has something to do with the deprecated Optim.DifferentiableFunction used in statisticalmodels-stopgap.jl -- hence suggesting its replacement by Optim.OnceDifferentiable

(List of Optim's functions: https://github.com/JuliaNLSolvers/Optim.jl/blob/master/docs/src/user/minimization.md)

---

```
> Pkg.add("DynamicDiscreteModels") 

>Unsatisfiable requirements detected for package Optim:
├─version range [0.7.8,0.7.8+) set by an explicit requirement
└─version range [0.0.0,0.5.0) required by package DynamicDiscreteModels, whose allowed version range is [0.0.0-,∞):
  ├─version range [0.0.0-,∞) set by an explicit requirement
  ├─version range [0.0.0-,∞) required by package RustModels, whose only allowed version is 0.0.0-:
│   └─version 0.0.0- set by fixed requirement (package is checked out, dirty or pinned)
  └─version range [0.0.0-,∞) required by package HiddenMarkovModels, whose allowed version range is [0.0.0-,∞):
    └─version range [0.0.0-,∞) required by package RustModels, whose only allowed version is 0.0.0-:
      └─[see above for RustModels backtrace]
The intersection of the requirements is empty.
filter_versions(::Dict{String,Base.Pkg.Types.VersionSet}, ::Dict{String,Dict{VersionNumber,Base.Pkg.Types.Available}}, ::Dict{AbstractString,Base.Pkg.Types.ResolveBacktraceItem}) at .\pkg\query.jl:299
prune_versions(::Dict{String,Base.Pkg.Types.VersionSet}, ::Dict{String,Dict{VersionNumber,Base.Pkg.Types.Available}}, ::Dict{AbstractString,Base.Pkg.Types.ResolveBacktraceItem}) at .\pkg\query.jl:328
prune_dependencies(::Dict{String,Base.Pkg.Types.VersionSet}, ::Dict{String,Dict{VersionNumber,Base.Pkg.Types.Available}}, ::Dict{AbstractString,Base.Pkg.Types.ResolveBacktraceItem}) at .\pkg\query.jl:546
resolve(::Dict{String,Base.Pkg.Types.VersionSet}, ::Dict{String,Dict{VersionNumber,Base.Pkg.Types.Available}}, ::Dict{String,Tuple{VersionNumber,Bool}}, ::Dict{String,Base.Pkg.Types.Fixed}, ::Dict{String,VersionNumber}, ::Set{String}) at .\pkg\entry.jl:498
resolve(::Dict{String,Base.Pkg.Types.VersionSet}, ::Dict{String,Dict{VersionNumber,Base.Pkg.Types.Available}}, ::Dict{String,Tuple{VersionNumber,Bool}}, ::Dict{String,Base.Pkg.Types.Fixed}) at .\pkg\entry.jl:479
edit(::Function, ::String, ::Base.Pkg.Types.VersionSet, ::Vararg{Base.Pkg.Types.VersionSet,N} where N) at .\pkg\entry.jl:30
(::Base.Pkg.Entry.##1#3{String,Base.Pkg.Types.VersionSet})() at .\task.jl:335
in add at base\pkg\pkg.jl:117
in #cd#1 at base\pkg\dir.jl:32
in withenv at base\env.jl:157
in cd at base\file.jl:59
in #3 at base\pkg\dir.jl:33
in add at base\pkg\entry.jl:51
in macro expansion at base\task.jl:303
in sync_end at base\task.jl:287

---

> Pkg.clone("git://github.com/BenConnault/RustModels.jl.git")

>Unsatisfiable requirements detected for package Optim:
├─version range [0.7.8,0.7.8+) set by an explicit requirement
└─version range [0.0.0,0.5.0) required by package DynamicDiscreteModels, whose allowed version range is [0.0.0-,∞):
  ├─version range [0.0.0-,∞) required by package RustModels, whose only allowed version is 0.0.0-:
│   └─version 0.0.0- set by fixed requirement (package is checked out, dirty or pinned)
  └─version range [0.0.0-,∞) required by package HiddenMarkovModels, whose allowed version range is [0.0.0-,∞):
    └─version range [0.0.0-,∞) required by package RustModels, whose only allowed version is 0.0.0-:
      └─[see above for RustModels backtrace]
The intersection of the requirements is empty.
in clone at base\pkg\pkg.jl:169
in #cd#1 at base\pkg\dir.jl:32
in withenv at base\env.jl:157
in cd at base\file.jl:59
in #3 at base\pkg\dir.jl:33
in clone at base\pkg\entry.jl:205
in resolve at base\pkg\entry.jl:479
in resolve at base\pkg\entry.jl:498
in prune_dependencies at base\pkg\query.jl:546
in prune_versions at base\pkg\query.jl:328
in filter_versions at base\pkg\query.jl:299
```
